### PR TITLE
Avoid "ValueError: At least one file selection option must be defined" error during installation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,3 +74,6 @@ example-filter = "example_filter:ExampleFilter"
 
 [tool.hatch.envs.default.scripts]
 test = "pygmentize -l example-lang -f example-format -F example-filter -O style=example-style test.exmpl"
+
+[tool.hatch.build.targets.wheel]
+packages = ["lexer", "styles"]


### PR DESCRIPTION
Since recent changes in `hatch`, the "ValueError: At least one file selection option must be defined" prevented the installation of the set of plugins.